### PR TITLE
fix: added missing allowed_methods enums to service_extra_config.json

### DIFF
--- a/service_extra_config.json
+++ b/service_extra_config.json
@@ -84,10 +84,12 @@
                         "type": "string",
                         "enum": [
                             "GET",
+                            "HEAD",
                             "POST",
                             "PUT",
+                            "PATCH",
                             "DELETE",
-                            "PATCH"
+                            "OPTIONS"
                         ]
                     }
                 },


### PR DESCRIPTION
# Summary

When using:
https://www.krakend.io/schema/v3.json

the allowed_methods in security/cors aren't accepting method types: HEAD and OPTIONS. 

This MR should be able to fix that and allow those methods in json-schema.